### PR TITLE
minor fixes, ec2 script

### DIFF
--- a/ec2config.yaml
+++ b/ec2config.yaml
@@ -83,6 +83,7 @@ dataverse:
   postgres:
     reporpm: https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
     version: 9.6
+    log_lock_waits: true
   previewers:
     enabled: true
   sampledata:
@@ -108,7 +109,7 @@ dataverse:
   srcdir: /tmp/dataverse
   thumbnails: true
   usermgmtkey: burrito
-  version: 4.15.1
+  version: 4.16
   wholetale:
     enabled: true
 


### PR DESCRIPTION
Fixes #7 Can't spin up on EC2 due to new dataverse.postgres.log_lock_waits setting

Upgrades the version to 4.16;
Adds the "log_lock_waits" parameter to the ec2 configuration - now required by the ec2 spinup script in dataverse-ansible.