### PR TITLE
Added "unittests:" to ec2config.yaml

### DIFF
--- a/ec2config.yaml
+++ b/ec2config.yaml
@@ -114,6 +114,9 @@ dataverse:
     version: 7.3.1
   srcdir: /tmp/dataverse
   thumbnails: true
+  unittests:
+    enabled: false
+    argument: '-DcompilerArgument=-Xlint:unchecked test -P all-unit-tests'
   usermgmtkey: burrito
   version: 4.16
 


### PR DESCRIPTION
This is to synchronize with dataverse-ansible, since this configuration section is now required.