### PR TITLE
allow API token to be retrieved from environment variable #24

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Copy `dvconfig.py.sample` to `dvconfig.py` (see the `cp` command below) and add 
     cp dvconfig.py.sample dvconfig.py
     vi dvconfig.py
 
+Note that the environment variable `$API_TOKEN` will override `api_token` in `dvconfig.py`.
+
 ## Adding sample data
 
 Assuming you have already run the `source` and `cd` commands above, you should be able to run the following command to create sample data.

--- a/create_sample_data.py
+++ b/create_sample_data.py
@@ -7,6 +7,11 @@ import requests
 from io import StringIO
 base_url = dvconfig.base_url
 api_token = dvconfig.api_token
+try:
+    api_token=os.environ['API_TOKEN']
+    print("Using API token from $API_TOKEN.")
+except:
+    print("Using API token from config file.")
 paths = dvconfig.sample_data
 api = Api(base_url, api_token)
 print(api.status)

--- a/destroy_all_dvobjects.py
+++ b/destroy_all_dvobjects.py
@@ -2,8 +2,14 @@ from pyDataverse.api import Api
 import json
 import dvconfig
 import requests
+import os
 base_url = dvconfig.base_url
 api_token = dvconfig.api_token
+try:
+    api_token=os.environ['API_TOKEN']
+    print("Using API token from $API_TOKEN.")
+except:
+    print("Using API token from config file.")
 api = Api(base_url, api_token)
 print('API status: ' +api.status)
 

--- a/export-api-token.sh
+++ b/export-api-token.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# source this file
+export API_TOKEN=`cat /tmp/setup-all.sh.out | grep apiToken | jq .data.apiToken | tr -d \"`


### PR DESCRIPTION
Closes #24 - Allow API token to be retrieved from an environment variable

I'm aware that there's a similar solution in pull request #14 

I'm also aware that here the dvconfig.py file is edited directly: https://github.com/GlobalDataverseCommunityConsortium/dataverse-ansible/blob/56ae75de0a796e515200d6830115f60e6ce3fd5e/tasks/sampledata.yml#L59

This is a small chunk and makes things easier for me.